### PR TITLE
Remove gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,0 @@
-org.gradle.java.home=/usr/lib/jvm/java-8-oracle


### PR DESCRIPTION
Was setting the JDK location in a unix-specific way. Whoever
builds the game needs to make sure the correct JDK is set on
their path.
